### PR TITLE
Added no lift version of transport_over_head_slightly_forward

### DIFF
--- a/tiago_clf_launch/config/tiago_motions.yaml
+++ b/tiago_clf_launch/config/tiago_motions.yaml
@@ -538,18 +538,16 @@ play_motion:
 
     transport_over_head_slightly_forward:
       joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint, 'torso_lift_joint']
-      meta: {description: transport_over_head, name: transport over head, usage: demo}
       points:
       - positions: [0.07, 1.02, -2.55, 0.63, -1.54, 1.33, -0.46, 0.15]
         time_from_start: 2.0
       meta:
-        name: Transport slightly above - in front of the head
+        name: Transport High
         usage: demo
         description: 'Moving gripper in front of, above the head.'
 
     place_in_box:
       joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint, 'torso_lift_joint']
-      meta: {description: transport_over_head, name: transport over head, usage: demo}
       points:
       - positions: [0.60, 0.63, -1.55, 1.13, -1.74, 1.29, -1.34, 0.25]
         time_from_start: 2.0

--- a/tiago_clf_launch/config/tiago_motions.yaml
+++ b/tiago_clf_launch/config/tiago_motions.yaml
@@ -536,6 +536,28 @@ play_motion:
       - positions: [0.09, 1.02, -3.01, 0.74, -1.54, 1.29, -0.20, 0.15]
         time_from_start: 2.0
 
+    transport_over_head_slightly_forward:
+      joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint, 'torso_lift_joint']
+      meta: {description: transport_over_head, name: transport over head, usage: demo}
+      points:
+      - positions: [0.07, 1.02, -2.55, 0.63, -1.54, 1.33, -0.46, 0.15]
+        time_from_start: 2.0
+      meta:
+        name: Transport slightly above - in front of the head
+        usage: demo
+        description: 'Moving gripper in front of, above the head.'
+
+    place_in_box:
+      joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint, 'torso_lift_joint']
+      meta: {description: transport_over_head, name: transport over head, usage: demo}
+      points:
+      - positions: [0.60, 0.63, -1.55, 1.13, -1.74, 1.29, -1.34, 0.25]
+        time_from_start: 2.0
+      meta:
+        name: Place in Box
+        usage: demo
+        description: 'A hard-coded placement motion.'
+
     transport_over_head_no_lift:
       joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint]
       meta: {description: transport_over_head_no_lift, name: transport over head no lift, usage: demo}

--- a/tiago_clf_launch/config/tiago_motions.yaml
+++ b/tiago_clf_launch/config/tiago_motions.yaml
@@ -546,6 +546,16 @@ play_motion:
         usage: demo
         description: 'Moving gripper in front of, above the head.'
 
+    transport_ohsf_no_lift:
+      joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint]
+      points:
+      - positions: [0.07, 1.02, -2.55, 0.63, -1.54, 1.33, -0.46]
+        time_from_start: 2.0
+      meta:
+        name: Transport High no lift
+        usage: demo
+        description: 'Moving gripper in front of, above the head.'
+
     place_in_box:
       joints: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint, 'torso_lift_joint']
       points:

--- a/tiago_clf_launch/launch/realsense.launch
+++ b/tiago_clf_launch/launch/realsense.launch
@@ -5,13 +5,17 @@
 <arg name="realsense_config" default="near"></arg>
 <arg name="camera_model" default="L515"/>
 
-<include if="$(eval arg('camera_model') == 'L515')" file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
-  <arg name="publish_transform" value="$(arg publish_transform)"/>
-</include>
+<group if="$(eval arg('camera_model') == 'L515')">
+  <include file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
+    <arg name="publish_transform" value="$(arg publish_transform)"/>
+  </include>
+</group>
 
-<include if="$(eval arg('camera_model') == 'D435i')" file="$(find tiago_clf_launch)/launch/rs_D435i_calibration.launch">
-  <arg name="publish_transform" value="$(arg publish_transform)"/>
-</include>
+<group if="$(eval arg('camera_model') == 'D435i')">
+  <include file="$(find tiago_clf_launch)/launch/rs_D435i_calibration.launch">
+    <arg name="publish_transform" value="$(arg publish_transform)"/>
+  </include>
+</group>
 
 <include file="$(find realsense2_camera)/launch/rs_camera.launch">
 	<arg name="depth_fps" value="30"/>

--- a/tiago_clf_launch/launch/realsense.launch
+++ b/tiago_clf_launch/launch/realsense.launch
@@ -17,6 +17,12 @@
   </include>
 </group>
 
+<group if="$(eval arg('camera_model') == 'D455')">
+  <include file="$(find tiago_clf_launch)/launch/rs_D455_calibration.launch">
+    <arg name="publish_transform" value="$(arg publish_transform)"/>
+  </include>
+</group>
+
 <include file="$(find realsense2_camera)/launch/rs_camera.launch">
 	<arg name="depth_fps" value="30"/>
 	<arg name="depth_width" value="640"/>

--- a/tiago_clf_launch/launch/realsense.launch
+++ b/tiago_clf_launch/launch/realsense.launch
@@ -4,10 +4,35 @@
 <arg name="publish_transform" default="True"></arg>
 <arg name="realsense_config" default="near"></arg>
 
-<include file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
-	<!-- <arg name="rgb" value="color" /> -->
+<!--include file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
 	<arg name="publish_transform" value="$(arg publish_transform)"/>
+</include-->
+
+<!-- 
+Make sure to add the following to the .bashrc:
+realsense_camera() {
+  if lsusb | grep -q "0b64"; then
+    export REALSENSE_CAMERA="L515"
+    echo "L515 camera detected, REALSENSE_CAMERA set to L515"
+  elif lsusb | grep -q "0b3a"; then
+    export REALSENSE_CAMERA="D435i"
+    echo "D435i camera detected, REALSENSE_CAMERA set to D435i"
+  else
+    echo "No RealSense camera detected"
+    unset REALSENSE_CAMERA  # Unset the variable if no camera is found
+  fi
+}
+realsense_camera
+-->
+
+<include if="$(eval env('REALSENSE_CAMERA') == 'L515')" file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
+  <arg name="publish_transform" value="$(arg publish_transform)"/>
 </include>
+
+<include if="$(eval env('REALSENSE_CAMERA') == 'D435i')" file="$(find tiago_clf_launch)/launch/rs_D435i_calibration.launch">
+  <arg name="publish_transform" value="$(arg publish_transform)"/>
+</include>
+
 
 <include file="$(find realsense2_camera)/launch/rs_camera.launch">
 	<!-- <arg name="rgb" value="color" /> -->

--- a/tiago_clf_launch/launch/realsense.launch
+++ b/tiago_clf_launch/launch/realsense.launch
@@ -3,39 +3,17 @@
 
 <arg name="publish_transform" default="True"></arg>
 <arg name="realsense_config" default="near"></arg>
+<arg name="camera_model" default="L515"/>
 
-<!--include file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
-	<arg name="publish_transform" value="$(arg publish_transform)"/>
-</include-->
-
-<!-- 
-Make sure to add the following to the .bashrc:
-realsense_camera() {
-  if lsusb | grep -q "0b64"; then
-    export REALSENSE_CAMERA="L515"
-    echo "L515 camera detected, REALSENSE_CAMERA set to L515"
-  elif lsusb | grep -q "0b3a"; then
-    export REALSENSE_CAMERA="D435i"
-    echo "D435i camera detected, REALSENSE_CAMERA set to D435i"
-  else
-    echo "No RealSense camera detected"
-    unset REALSENSE_CAMERA  # Unset the variable if no camera is found
-  fi
-}
-realsense_camera
--->
-
-<include if="$(eval env('REALSENSE_CAMERA') == 'L515')" file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
+<include if="$(eval arg('camera_model') == 'L515')" file="$(find tiago_clf_launch)/launch/rs_l515_calibration.launch">
   <arg name="publish_transform" value="$(arg publish_transform)"/>
 </include>
 
-<include if="$(eval env('REALSENSE_CAMERA') == 'D435i')" file="$(find tiago_clf_launch)/launch/rs_D435i_calibration.launch">
+<include if="$(eval arg('camera_model') == 'D435i')" file="$(find tiago_clf_launch)/launch/rs_D435i_calibration.launch">
   <arg name="publish_transform" value="$(arg publish_transform)"/>
 </include>
-
 
 <include file="$(find realsense2_camera)/launch/rs_camera.launch">
-	<!-- <arg name="rgb" value="color" /> -->
 	<arg name="depth_fps" value="30"/>
 	<arg name="depth_width" value="640"/>
 	<arg name="depth_height" value="480"/>

--- a/tiago_clf_launch/launch/rs_D435i_calibration.launch
+++ b/tiago_clf_launch/launch/rs_D435i_calibration.launch
@@ -1,0 +1,14 @@
+<launch>
+
+  <arg name="publish_transform" default="True"></arg>
+
+  <group if="$(arg publish_transform)">
+    <node pkg="tf2_ros" type="static_transform_publisher" name="realsense_calibration" args="0.0056756 0.045364 -0.02167 -0.0069478 -0.0099311 0.0092912 0.99988 realsense_link camera_link" />
+  </group>
+
+  <group unless="$(arg publish_transform)"> 
+    <arg name="command_args" value="-d $(find tiago_clf_launch)/config/calibrate.rviz" />
+    <node name="$(anon rviz)" pkg="rviz" type="rviz" respawn="false" args="$(arg command_args)" output="log"/>
+  </group>
+
+</launch>

--- a/tiago_clf_launch/launch/rs_D455_calibration.launch
+++ b/tiago_clf_launch/launch/rs_D455_calibration.launch
@@ -1,0 +1,14 @@
+<launch>
+
+  <arg name="publish_transform" default="True"></arg>
+
+  <group if="$(arg publish_transform)">
+    <node pkg="tf2_ros" type="static_transform_publisher" name="realsense_calibration" args="-0.0019368 0.064561 0.0076106 -0.0087252 0.017452 0.0001523 0.99981 realsense_link camera_link" />
+  </group>
+
+  <group unless="$(arg publish_transform)"> 
+    <arg name="command_args" value="-d $(find tiago_clf_launch)/config/calibrate.rviz" />
+    <node name="$(anon rviz)" pkg="rviz" type="rviz" respawn="false" args="$(arg command_args)" output="log"/>
+  </group>
+
+</launch>


### PR DESCRIPTION
This pull request includes an addition to the `tiago_motions.yaml` configuration file. The change introduces a new motion sequence for the TIAGo robot.

New motion sequence added:

* [`tiago_clf_launch/config/tiago_motions.yaml`](diffhunk://#diff-15910c2e7008c885e4e85b6256cf63f8c284a4b5227854814bbc52eeb0613feeR549-R558): Added a new motion sequence named `transport_ohsf_no_lift` with specified joint positions and metadata for usage and description.